### PR TITLE
Replace sys.puts with console.log

### DIFF
--- a/a2switch.js
+++ b/a2switch.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 var fs = require('fs');
-var sys = require('sys');
 var isRoot = require('is-root');
 var inquirer = require('inquirer');
 var exec = require('child_process').exec;
@@ -73,7 +72,7 @@ function reloadApache() {
 }
 
 function puts(error, stdout, stderr) {
-	sys.puts(stdout);
+	console.log(stdout);
 }
 
 function handleErr(err) {


### PR DESCRIPTION
`sys.puts` has been deprecated for quite some time now and will be
removed in the near future.

Related: https://github.com/iojs/io.js/issues/1704
